### PR TITLE
Add pan/zoom to pixel canvas

### DIFF
--- a/client/src/PixelCanvas.jsx
+++ b/client/src/PixelCanvas.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 
 const TILE_PX = 10; // top‑level tile rendered 10×10 CSS pixels
 
@@ -20,6 +20,10 @@ function drawTile(ctx, tile, x, y, size) {
 
 export default function PixelCanvas({ world, socket, myColor }) {
   const ref = useRef(null);
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const dragging = useRef(false);
+  const lastPos = useRef({ x: 0, y: 0 });
 
   useEffect(() => {
     const canvas = ref.current;
@@ -28,18 +32,21 @@ export default function PixelCanvas({ world, socket, myColor }) {
     canvas.width = world[0].length * TILE_PX;
     canvas.height = world.length * TILE_PX;
 
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.setTransform(scale, 0, 0, scale, offset.x, offset.y);
+
     world.forEach((row, y) => {
       row.forEach((tile, x) => {
         drawTile(ctx, tile, x * TILE_PX, y * TILE_PX, TILE_PX);
       });
     });
-  }, [world]);
+  }, [world, scale, offset]);
 
   function handleClick(e) {
     const rect = ref.current.getBoundingClientRect();
-    let x = e.clientX - rect.left;
-    let y = e.clientY - rect.top;
+    let x = (e.clientX - rect.left - offset.x) / scale;
+    let y = (e.clientY - rect.top - offset.y) / scale;
 
     let path = [];
     let tiles = world;
@@ -69,5 +76,45 @@ export default function PixelCanvas({ world, socket, myColor }) {
     socket.emit('click', { path, color: myColor });
   }
 
-  return <canvas ref={ref} onClick={handleClick} className="border" />;
+  function handleMouseDown(e) {
+    dragging.current = true;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+  }
+
+  function handleMouseMove(e) {
+    if (!dragging.current) return;
+    const dx = e.clientX - lastPos.current.x;
+    const dy = e.clientY - lastPos.current.y;
+    setOffset(prev => ({ x: prev.x + dx, y: prev.y + dy }));
+    lastPos.current = { x: e.clientX, y: e.clientY };
+  }
+
+  function handleMouseUp() {
+    dragging.current = false;
+  }
+
+  function handleWheel(e) {
+    e.preventDefault();
+    const rect = ref.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const factor = e.deltaY < 0 ? 1.1 : 0.9;
+    setOffset(prev => ({
+      x: x - (x - prev.x) * factor,
+      y: y - (y - prev.y) * factor,
+    }));
+    setScale(prev => Math.max(0.2, Math.min(10, prev * factor)));
+  }
+
+  return (
+    <canvas
+      ref={ref}
+      onClick={handleClick}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      onWheel={handleWheel}
+      className="border" />
+  );
 }


### PR DESCRIPTION
## Summary
- upgrade PixelCanvas to support panning via mouse drag
- support zooming with the mouse wheel
- update click handling to account for pan and zoom

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68514075ed748325a740942d66860021