### PR TITLE
Adjust world size and claim count

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,7 +16,7 @@ function App() {
         let ref = next;
         for (let i = 0; i < path.length; i++) {
           const idx = path[i];
-          const side = i === 0 ? 80 : 8;
+          const side = i === 0 ? ref[0].length : 8;
           const y = Math.floor(idx / side);
           const x = idx % side;
           if (i === path.length - 1) {

--- a/client/src/PixelCanvas.jsx
+++ b/client/src/PixelCanvas.jsx
@@ -45,7 +45,7 @@ export default function PixelCanvas({ world, socket, myColor }) {
     let tiles = world;
     let size = TILE_PX;
     while (true) {
-      const side = tiles[0].length; // 80 for root, 8 for children, …
+      const side = tiles[0].length; // root width (8) or 8 for children
       const tx = Math.floor(x / size);
       const ty = Math.floor(y / size);
       const idx = ty * side + tx;

--- a/server/server.js
+++ b/server/server.js
@@ -4,9 +4,9 @@ const http    = require('http');
 const path    = require('path');
 const { Server } = require('socket.io');
 
-const WORLD_W = 80;
-const WORLD_H = 60;
-const CLAIMS_TO_OWN = 100;
+const WORLD_W = 8;
+const WORLD_H = 6;
+const CLAIMS_TO_OWN = 3;
 const SUBDIV = 8;
 
 // ─── data model ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- shrink initial grid to `8x6`
- reduce claims required for ownership to `3`
- make client logic use actual world width
- update comment about grid width

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685140c2e3048325928bc66854963968