### PR TITLE
Add grid/border toggles with toolbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+client/dist/

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
 import { io } from 'socket.io-client';
 import PixelCanvas from './PixelCanvas';
+import Toolbar from './Toolbar';
 
 const socket = io('http://localhost:3000');
 
 function App() {
   const [world, setWorld] = useState(null);
   const [myColor] = useState(() => `hsl(${Math.random()*360},70%,50%)`);
+  const [showGrid, setShowGrid] = useState(true);
+  const [showBorders, setShowBorders] = useState(true);
 
   useEffect(() => {
     socket.on('init', data => setWorld(data.world));
@@ -41,7 +44,21 @@ function App() {
   if (!world) return <p className="p-4 text-center">Loading world…</p>;
 
   return (
-    <PixelCanvas world={world} socket={socket} myColor={myColor} />
+    <>
+      <Toolbar
+        showGrid={showGrid}
+        toggleGrid={() => setShowGrid(prev => !prev)}
+        showBorders={showBorders}
+        toggleBorders={() => setShowBorders(prev => !prev)}
+      />
+      <PixelCanvas
+        world={world}
+        socket={socket}
+        myColor={myColor}
+        showGrid={showGrid}
+        showOwnedBorders={showBorders}
+      />
+    </>
   );
 }
 

--- a/client/src/PixelCanvas.jsx
+++ b/client/src/PixelCanvas.jsx
@@ -57,21 +57,17 @@ function gridify(children) {
   }, []);
 }
 
-function drawTile(ctx, tile, grid, gx, gy, x, y, size, myId, parentOwnerId = null) {
+function drawTilePixels(ctx, tile, x, y, size, myId, parentOwnerId = null) {
   const isOwnedByMe = tile.owner?.id === myId;
 
   if (tile.children) {
     const childSize = size / 8;
-    const childGrid = gridify(tile.children);
     tile.children.forEach((child, i) => {
       const cx = i % 8;
       const cy = Math.floor(i / 8);
-      drawTile(
+      drawTilePixels(
         ctx,
         child,
-        childGrid,
-        cx,
-        cy,
         x + cx * childSize,
         y + cy * childSize,
         childSize,
@@ -86,6 +82,33 @@ function drawTile(ctx, tile, grid, gx, gy, x, y, size, myId, parentOwnerId = nul
 
   if (!tile.owner && tile.claims > 0 && !tile.children) {
     drawProgress(ctx, x, y, size, tile.claims / CLAIMS_TO_OWN);
+  }
+}
+
+function drawTileLines(ctx, tile, grid, gx, gy, x, y, size, myId, showGrid, showOwnedBorders, parentOwnerId = null) {
+  if (!showGrid && !showOwnedBorders) return;
+
+  if (tile.children) {
+    const childSize = size / 8;
+    const childGrid = gridify(tile.children);
+    tile.children.forEach((child, i) => {
+      const cx = i % 8;
+      const cy = Math.floor(i / 8);
+      drawTileLines(
+        ctx,
+        child,
+        childGrid,
+        cx,
+        cy,
+        x + cx * childSize,
+        y + cy * childSize,
+        childSize,
+        myId,
+        showGrid,
+        showOwnedBorders,
+        tile.owner?.id || parentOwnerId,
+      );
+    });
   }
 
   const ownerId = tile.owner?.id || parentOwnerId;
@@ -103,9 +126,6 @@ function drawTile(ctx, tile, grid, gx, gy, x, y, size, myId, parentOwnerId = nul
   const neighborOwnerId = line => line ? (line.owner?.id || parentOwnerId) : parentOwnerId;
   const needOutline = line => isMine && neighborOwnerId(line) !== ownerId;
 
-  // to avoid double-drawing borders we only render the top/left sides for
-  // interior edges. Bottom and right edges are handled by the neighboring tiles
-  // except at world boundaries where no neighbor exists.
   const shouldDraw = {
     top: true,
     left: true,
@@ -114,40 +134,40 @@ function drawTile(ctx, tile, grid, gx, gy, x, y, size, myId, parentOwnerId = nul
   };
 
   const drawGreen = {
-    top: shouldDraw.top && needOutline(neighbors.top),
-    right: shouldDraw.right && needOutline(neighbors.right),
-    bottom: shouldDraw.bottom && needOutline(neighbors.bottom),
-    left: shouldDraw.left && needOutline(neighbors.left),
+    top: showOwnedBorders && shouldDraw.top && needOutline(neighbors.top),
+    right: showOwnedBorders && shouldDraw.right && needOutline(neighbors.right),
+    bottom: showOwnedBorders && shouldDraw.bottom && needOutline(neighbors.bottom),
+    left: showOwnedBorders && shouldDraw.left && needOutline(neighbors.left),
   };
 
-  // draw default grey borders, skipping sides with green outline
-  ctx.strokeStyle = '#666';
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  let drewGrey = false;
-  if (shouldDraw.top && !drawGreen.top) {
-    ctx.moveTo(x, y);
-    ctx.lineTo(x + size, y);
-    drewGrey = true;
+  if (showGrid) {
+    ctx.strokeStyle = '#666';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    let drewGrey = false;
+    if (shouldDraw.top && !drawGreen.top) {
+      ctx.moveTo(x, y);
+      ctx.lineTo(x + size, y);
+      drewGrey = true;
+    }
+    if (shouldDraw.right && !drawGreen.right) {
+      ctx.moveTo(x + size, y);
+      ctx.lineTo(x + size, y + size);
+      drewGrey = true;
+    }
+    if (shouldDraw.bottom && !drawGreen.bottom) {
+      ctx.moveTo(x + size, y + size);
+      ctx.lineTo(x, y + size);
+      drewGrey = true;
+    }
+    if (shouldDraw.left && !drawGreen.left) {
+      ctx.moveTo(x, y + size);
+      ctx.lineTo(x, y);
+      drewGrey = true;
+    }
+    if (drewGrey) ctx.stroke();
   }
-  if (shouldDraw.right && !drawGreen.right) {
-    ctx.moveTo(x + size, y);
-    ctx.lineTo(x + size, y + size);
-    drewGrey = true;
-  }
-  if (shouldDraw.bottom && !drawGreen.bottom) {
-    ctx.moveTo(x + size, y + size);
-    ctx.lineTo(x, y + size);
-    drewGrey = true;
-  }
-  if (shouldDraw.left && !drawGreen.left) {
-    ctx.moveTo(x, y + size);
-    ctx.lineTo(x, y);
-    drewGrey = true;
-  }
-  if (drewGrey) ctx.stroke();
 
-  // helper to draw glowing green side
   const glow = (fromX, fromY, toX, toY, offX, offY) => {
     ctx.save();
     ctx.strokeStyle = 'green';
@@ -169,7 +189,7 @@ function drawTile(ctx, tile, grid, gx, gy, x, y, size, myId, parentOwnerId = nul
   if (drawGreen.left) glow(x, y + size, x, y, -2, 0);
 }
 
-export default function PixelCanvas({ world, socket, myColor }) {
+export default function PixelCanvas({ world, socket, myColor, showGrid, showOwnedBorders }) {
   const ref = useRef(null);
   const [scale, setScale] = useState(1);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
@@ -242,20 +262,20 @@ export default function PixelCanvas({ world, socket, myColor }) {
 
     world.forEach((row, y) => {
       row.forEach((tile, x) => {
-        drawTile(
-          ctx,
-          tile,
-          world,
-          x,
-          y,
-          offset.x + x * rootSize,
-          offset.y + y * rootSize,
-          rootSize,
-          myId,
-        );
+        const px = offset.x + x * rootSize;
+        const py = offset.y + y * rootSize;
+        drawTilePixels(ctx, tile, px, py, rootSize, myId);
       });
     });
-  }, [world, scale, offset, size, socket.id]);
+
+    world.forEach((row, y) => {
+      row.forEach((tile, x) => {
+        const px = offset.x + x * rootSize;
+        const py = offset.y + y * rootSize;
+        drawTileLines(ctx, tile, world, x, y, px, py, rootSize, myId, showGrid, showOwnedBorders);
+      });
+    });
+  }, [world, scale, offset, size, socket.id, showGrid, showOwnedBorders]);
 
   function handleClick(e) {
     const rect = ref.current.getBoundingClientRect();

--- a/client/src/Toolbar.jsx
+++ b/client/src/Toolbar.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function Toolbar({ showGrid, toggleGrid, showBorders, toggleBorders }) {
+  return (
+    <div className="toolbar">
+      <label>
+        <input type="checkbox" checked={showGrid} onChange={toggleGrid} />
+        Grid
+      </label>
+      <label>
+        <input type="checkbox" checked={showBorders} onChange={toggleBorders} />
+        Owned borders
+      </label>
+    </div>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -13,3 +13,17 @@ canvas {
   height: 100vh;
   display: block;
 }
+
+.toolbar {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.toolbar label {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- add floating Toolbar with checkboxes
- support toggling grid lines and owned borders
- factor tile rendering into separate pixel and border passes
- add toolbar styles
- ignore built client/dist output

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852d760e0008325b351c05182e15b98