### PR TITLE
Fix owner border lines

### DIFF
--- a/client/src/PixelCanvas.jsx
+++ b/client/src/PixelCanvas.jsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from 'react';
+import { computeOwnedBorders } from './utils/ownedBorders.js';
 
 const TILE_PX = 10; // top-level tile rendered 10×10 CSS pixels
 const CLAIMS_TO_OWN = 3;
@@ -133,12 +134,7 @@ function drawTileLines(ctx, tile, grid, gx, gy, x, y, size, myId, showGrid, show
     bottom: gy === height - 1,
   };
 
-  const drawGreen = {
-    top: showOwnedBorders && shouldDraw.top && needOutline(neighbors.top),
-    right: showOwnedBorders && shouldDraw.right && needOutline(neighbors.right),
-    bottom: showOwnedBorders && shouldDraw.bottom && needOutline(neighbors.bottom),
-    left: showOwnedBorders && shouldDraw.left && needOutline(neighbors.left),
-  };
+  const drawGreen = computeOwnedBorders(tile, grid, gx, gy, myId, showOwnedBorders, parentOwnerId);
 
   if (showGrid) {
     ctx.strokeStyle = '#666';

--- a/client/src/utils/ownedBorders.js
+++ b/client/src/utils/ownedBorders.js
@@ -1,0 +1,23 @@
+export function computeOwnedBorders(tile, grid, gx, gy, myId, showOwnedBorders, parentOwnerId = null) {
+  const ownerId = tile.owner?.id || parentOwnerId;
+  const isMine = ownerId === myId;
+
+  const width = grid[0].length;
+  const height = grid.length;
+  const neighbors = {
+    top: gy > 0 ? grid[gy - 1][gx] : null,
+    right: gx < width - 1 ? grid[gy][gx + 1] : null,
+    bottom: gy < height - 1 ? grid[gy + 1][gx] : null,
+    left: gx > 0 ? grid[gy][gx - 1] : null,
+  };
+
+  const neighborOwnerId = line => line ? (line.owner?.id || parentOwnerId) : parentOwnerId;
+  const needOutline = line => isMine && neighborOwnerId(line) !== ownerId;
+
+  return {
+    top: showOwnedBorders && needOutline(neighbors.top),
+    right: showOwnedBorders && needOutline(neighbors.right),
+    bottom: showOwnedBorders && needOutline(neighbors.bottom),
+    left: showOwnedBorders && needOutline(neighbors.left),
+  };
+}

--- a/client/test/ownedBorders.test.js
+++ b/client/test/ownedBorders.test.js
@@ -1,0 +1,71 @@
+import assert from 'assert';
+import { computeOwnedBorders } from '../src/utils/ownedBorders.js';
+
+function makeTile(id) {
+  return { owner: id ? { id, color: '#' + id } : null, children: null };
+}
+
+// simple grid helper
+function grid(rows) {
+  return rows;
+}
+
+(function testDifferentNeighbor() {
+  const myTile = makeTile('me');
+  const other = makeTile('other');
+  const world = grid([[myTile, other]]);
+  const res = computeOwnedBorders(myTile, world, 0, 0, 'me', true);
+  assert.deepStrictEqual(res, { top: true, right: true, bottom: true, left: true });
+})();
+
+(function testSameOwnerNeighbor() {
+  const myTile = makeTile('me');
+  const myTile2 = makeTile('me');
+  const world = grid([[myTile, myTile2]]);
+  const res = computeOwnedBorders(myTile, world, 0, 0, 'me', true);
+  assert.deepStrictEqual(res, { top: true, right: false, bottom: true, left: true });
+})();
+
+(function testBordersDisabled() {
+  const myTile = makeTile('me');
+  const world = grid([[myTile]]);
+  const res = computeOwnedBorders(myTile, world, 0, 0, 'me', false);
+  assert.deepStrictEqual(res, { top: false, right: false, bottom: false, left: false });
+})();
+
+(function testWorldEdge() {
+  const myTile = makeTile('me');
+  const world = grid([[myTile]]);
+  const res = computeOwnedBorders(myTile, world, 0, 0, 'me', true);
+  assert.deepStrictEqual(res, { top: true, right: true, bottom: true, left: true });
+})();
+
+(function testNotMineNoOutline() {
+  const otherTile = makeTile('other');
+  const world = grid([[otherTile]]);
+  const res = computeOwnedBorders(otherTile, world, 0, 0, 'me', true);
+  assert.deepStrictEqual(res, { top: false, right: false, bottom: false, left: false });
+})();
+
+(function testChildBoundaryWithDifferentNeighbor() {
+  const parent = makeTile('me');
+  const childA = makeTile('me');
+  const childB = makeTile('me');
+  parent.children = [childA, childB];
+  const childGrid = [[childA, childB]];
+  const neighbor = makeTile('other');
+  // compute border for rightmost child; neighbor is on the right at parent level
+  const res = computeOwnedBorders(childB, childGrid, 1, 0, 'me', true, 'me');
+  assert.deepStrictEqual(res, { top: false, right: false, bottom: false, left: false });
+})();
+
+(function testChildWorldEdgeNoOutline() {
+  const parent = makeTile('me');
+  const child = makeTile('me');
+  parent.children = [child];
+  const childGrid = [[child]];
+  const res = computeOwnedBorders(child, childGrid, 0, 0, 'me', true, 'me');
+  assert.deepStrictEqual(res, { top: false, right: false, bottom: false, left: false });
+})();
+
+console.log('owned border tests passed');


### PR DESCRIPTION
## Summary
- allow owned borders on all sides
- expose owned border logic for testing
- add tests for owned border calculations
- add edge case tests for border calculation

## Testing
- `node client/test/ownedBorders.test.js`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6852e390466c83259116449e9c6d8ed6