### PR TITLE
Fix owned border overlap

### DIFF
--- a/client/src/PixelCanvas.jsx
+++ b/client/src/PixelCanvas.jsx
@@ -86,8 +86,31 @@ function drawTilePixels(ctx, tile, x, y, size, myId, parentOwnerId = null) {
   }
 }
 
-function drawTileLines(ctx, tile, grid, gx, gy, x, y, size, myId, showGrid, showOwnedBorders, parentOwnerId = null) {
+function drawTileLines(
+  ctx,
+  tile,
+  grid,
+  gx,
+  gy,
+  x,
+  y,
+  size,
+  myId,
+  showGrid,
+  showOwnedBorders,
+  parentOwnerId = null,
+  parentNeighbors = {},
+) {
   if (!showGrid && !showOwnedBorders) return;
+
+  const width = grid[0].length;
+  const height = grid.length;
+  const neighbors = {
+    top: gy > 0 ? grid[gy - 1][gx] : null,
+    right: gx < width - 1 ? grid[gy][gx + 1] : null,
+    bottom: gy < height - 1 ? grid[gy + 1][gx] : null,
+    left: gx > 0 ? grid[gy][gx - 1] : null,
+  };
 
   if (tile.children) {
     const childSize = size / 8;
@@ -108,24 +131,13 @@ function drawTileLines(ctx, tile, grid, gx, gy, x, y, size, myId, showGrid, show
         showGrid,
         showOwnedBorders,
         tile.owner?.id || parentOwnerId,
+        neighbors,
       );
     });
   }
 
   const ownerId = tile.owner?.id || parentOwnerId;
   const isMine = ownerId === myId;
-
-  const width = grid[0].length;
-  const height = grid.length;
-  const neighbors = {
-    top: gy > 0 ? grid[gy - 1][gx] : null,
-    right: gx < width - 1 ? grid[gy][gx + 1] : null,
-    bottom: gy < height - 1 ? grid[gy + 1][gx] : null,
-    left: gx > 0 ? grid[gy][gx - 1] : null,
-  };
-
-  const neighborOwnerId = line => line ? (line.owner?.id || parentOwnerId) : parentOwnerId;
-  const needOutline = line => isMine && neighborOwnerId(line) !== ownerId;
 
   const shouldDraw = {
     top: true,
@@ -134,29 +146,29 @@ function drawTileLines(ctx, tile, grid, gx, gy, x, y, size, myId, showGrid, show
     bottom: gy === height - 1,
   };
 
-  const drawGreen = computeOwnedBorders(tile, grid, gx, gy, myId, showOwnedBorders, parentOwnerId);
+  const drawGreen = computeOwnedBorders(tile, grid, gx, gy, myId, showOwnedBorders, parentOwnerId, parentNeighbors);
 
   if (showGrid) {
     ctx.strokeStyle = '#666';
     ctx.lineWidth = 1;
     ctx.beginPath();
     let drewGrey = false;
-    if (shouldDraw.top && !drawGreen.top) {
+    if (shouldDraw.top && drawGreen.top.length === 0) {
       ctx.moveTo(x, y);
       ctx.lineTo(x + size, y);
       drewGrey = true;
     }
-    if (shouldDraw.right && !drawGreen.right) {
+    if (shouldDraw.right && drawGreen.right.length === 0) {
       ctx.moveTo(x + size, y);
       ctx.lineTo(x + size, y + size);
       drewGrey = true;
     }
-    if (shouldDraw.bottom && !drawGreen.bottom) {
+    if (shouldDraw.bottom && drawGreen.bottom.length === 0) {
       ctx.moveTo(x + size, y + size);
       ctx.lineTo(x, y + size);
       drewGrey = true;
     }
-    if (shouldDraw.left && !drawGreen.left) {
+    if (shouldDraw.left && drawGreen.left.length === 0) {
       ctx.moveTo(x, y + size);
       ctx.lineTo(x, y);
       drewGrey = true;
@@ -179,10 +191,14 @@ function drawTileLines(ctx, tile, grid, gx, gy, x, y, size, myId, showGrid, show
     ctx.restore();
   };
 
-  if (drawGreen.top) glow(x, y, x + size, y, 0, -2);
-  if (drawGreen.right) glow(x + size, y, x + size, y + size, 2, 0);
-  if (drawGreen.bottom) glow(x + size, y + size, x, y + size, 0, 2);
-  if (drawGreen.left) glow(x, y + size, x, y, -2, 0);
+  drawGreen.top.forEach(([s, e]) =>
+    glow(x + s * size, y, x + e * size, y, 0, -2));
+  drawGreen.right.forEach(([s, e]) =>
+    glow(x + size, y + s * size, x + size, y + e * size, 2, 0));
+  drawGreen.bottom.forEach(([s, e]) =>
+    glow(x + e * size, y + size, x + s * size, y + size, 0, 2));
+  drawGreen.left.forEach(([s, e]) =>
+    glow(x, y + e * size, x, y + s * size, -2, 0));
 }
 
 export default function PixelCanvas({ world, socket, myColor, showGrid, showOwnedBorders }) {

--- a/client/src/utils/ownedBorders.js
+++ b/client/src/utils/ownedBorders.js
@@ -1,4 +1,15 @@
-export function computeOwnedBorders(tile, grid, gx, gy, myId, showOwnedBorders, parentOwnerId = null) {
+const SUBDIV = 8;
+
+export function computeOwnedBorders(
+  tile,
+  grid,
+  gx,
+  gy,
+  myId,
+  showOwnedBorders,
+  parentOwnerId = null,
+  parentNeighbors = {},
+) {
   const ownerId = tile.owner?.id || parentOwnerId;
   const isMine = ownerId === myId;
 
@@ -11,13 +22,45 @@ export function computeOwnedBorders(tile, grid, gx, gy, myId, showOwnedBorders, 
     left: gx > 0 ? grid[gy][gx - 1] : null,
   };
 
-  const neighborOwnerId = line => line ? (line.owner?.id || parentOwnerId) : parentOwnerId;
-  const needOutline = line => isMine && neighborOwnerId(line) !== ownerId;
+  const ownerOf = (t, fallback = null) => (t ? t.owner?.id || fallback : fallback);
+
+  function segmentsFor(dir) {
+    if (!showOwnedBorders || !isMine) return [];
+
+    let neighbor = neighbors[dir];
+    let neighborOwner = ownerOf(neighbor, parentOwnerId);
+
+    if (!neighbor) {
+      neighbor = parentNeighbors[dir];
+      neighborOwner = ownerOf(neighbor, parentOwnerId);
+      if (parentOwnerId === ownerId) return [];
+      return neighborOwner !== ownerId ? [[0, 1]] : [];
+    }
+
+    if (!neighbor.children) {
+      return neighborOwner !== ownerId ? [[0, 1]] : [];
+    }
+
+    const segs = [];
+    for (let i = 0; i < SUBDIV; i++) {
+      let idx;
+      if (dir === 'top') idx = (SUBDIV - 1) * SUBDIV + i;
+      if (dir === 'bottom') idx = i;
+      if (dir === 'left') idx = i * SUBDIV + (SUBDIV - 1);
+      if (dir === 'right') idx = i * SUBDIV;
+      const child = neighbor.children[idx];
+      const childOwner = ownerOf(child, neighborOwner);
+      if (childOwner !== ownerId) {
+        segs.push([i / SUBDIV, (i + 1) / SUBDIV]);
+      }
+    }
+    return segs;
+  }
 
   return {
-    top: showOwnedBorders && needOutline(neighbors.top),
-    right: showOwnedBorders && needOutline(neighbors.right),
-    bottom: showOwnedBorders && needOutline(neighbors.bottom),
-    left: showOwnedBorders && needOutline(neighbors.left),
+    top: segmentsFor('top'),
+    right: segmentsFor('right'),
+    bottom: segmentsFor('bottom'),
+    left: segmentsFor('left'),
   };
 }

--- a/client/test/ownedBorders.test.js
+++ b/client/test/ownedBorders.test.js
@@ -15,7 +15,8 @@ function grid(rows) {
   const other = makeTile('other');
   const world = grid([[myTile, other]]);
   const res = computeOwnedBorders(myTile, world, 0, 0, 'me', true);
-  assert.deepStrictEqual(res, { top: true, right: true, bottom: true, left: true });
+  const full = [[0, 1]];
+  assert.deepStrictEqual(res, { top: full, right: full, bottom: full, left: full });
 })();
 
 (function testSameOwnerNeighbor() {
@@ -23,28 +24,30 @@ function grid(rows) {
   const myTile2 = makeTile('me');
   const world = grid([[myTile, myTile2]]);
   const res = computeOwnedBorders(myTile, world, 0, 0, 'me', true);
-  assert.deepStrictEqual(res, { top: true, right: false, bottom: true, left: true });
+  const full = [[0, 1]];
+  assert.deepStrictEqual(res, { top: full, right: [], bottom: full, left: full });
 })();
 
 (function testBordersDisabled() {
   const myTile = makeTile('me');
   const world = grid([[myTile]]);
   const res = computeOwnedBorders(myTile, world, 0, 0, 'me', false);
-  assert.deepStrictEqual(res, { top: false, right: false, bottom: false, left: false });
+  assert.deepStrictEqual(res, { top: [], right: [], bottom: [], left: [] });
 })();
 
 (function testWorldEdge() {
   const myTile = makeTile('me');
   const world = grid([[myTile]]);
   const res = computeOwnedBorders(myTile, world, 0, 0, 'me', true);
-  assert.deepStrictEqual(res, { top: true, right: true, bottom: true, left: true });
+  const full = [[0, 1]];
+  assert.deepStrictEqual(res, { top: full, right: full, bottom: full, left: full });
 })();
 
 (function testNotMineNoOutline() {
   const otherTile = makeTile('other');
   const world = grid([[otherTile]]);
   const res = computeOwnedBorders(otherTile, world, 0, 0, 'me', true);
-  assert.deepStrictEqual(res, { top: false, right: false, bottom: false, left: false });
+  assert.deepStrictEqual(res, { top: [], right: [], bottom: [], left: [] });
 })();
 
 (function testChildBoundaryWithDifferentNeighbor() {
@@ -54,9 +57,8 @@ function grid(rows) {
   parent.children = [childA, childB];
   const childGrid = [[childA, childB]];
   const neighbor = makeTile('other');
-  // compute border for rightmost child; neighbor is on the right at parent level
-  const res = computeOwnedBorders(childB, childGrid, 1, 0, 'me', true, 'me');
-  assert.deepStrictEqual(res, { top: false, right: false, bottom: false, left: false });
+  const res = computeOwnedBorders(childB, childGrid, 1, 0, 'me', true, 'me', { right: neighbor });
+  assert.deepStrictEqual(res, { top: [], right: [], bottom: [], left: [] });
 })();
 
 (function testChildWorldEdgeNoOutline() {
@@ -65,7 +67,24 @@ function grid(rows) {
   parent.children = [child];
   const childGrid = [[child]];
   const res = computeOwnedBorders(child, childGrid, 0, 0, 'me', true, 'me');
-  assert.deepStrictEqual(res, { top: false, right: false, bottom: false, left: false });
+  assert.deepStrictEqual(res, { top: [], right: [], bottom: [], left: [] });
+})();
+
+(function testParentChildSharedEdge() {
+  const top = makeTile('me');
+  const neighborParent = makeTile('other');
+  neighborParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const child = makeTile('me');
+  neighborParent.children[0] = child; // top-left child
+  const childRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => neighborParent.children[y * 8 + x]));
+  const world = [[top, neighborParent]];
+  const resTop = computeOwnedBorders(top, world, 0, 0, 'me', true);
+  const expected = [];
+  for (let i = 1; i < 8; i++) expected.push([i / 8, (i + 1) / 8]);
+  assert.deepStrictEqual(resTop.right, expected);
+  const resChild = computeOwnedBorders(child, childRows, 0, 0, 'me', true, 'other', { top });
+  assert.deepStrictEqual(resChild.top, []);
 })();
 
 console.log('owned border tests passed');

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "scripts": {
         "dev": "concurrently -k -n \"SERVER,CLIENT\" -c \"cyan,magenta\" \"npm:dev --workspace=server\" \"npm:dev --workspace=client\"",
         "build": "npm run build --workspace=client",
-        "start": "npm run build && npm start --workspace=server"
+        "start": "npm run build && npm start --workspace=server",
+        "test": "node client/test/ownedBorders.test.js"
     }
 }


### PR DESCRIPTION
## Summary
- refine border calculation to handle shared edges between parent and child tiles
- draw green borders per segment in `PixelCanvas`
- update tests for new border logic
- add `test` script to `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685410ca96d083258fb22395b2cafcd4