### PR TITLE
Add cousin border tests

### DIFF
--- a/client/src/utils/ownedBorders.js
+++ b/client/src/utils/ownedBorders.js
@@ -33,6 +33,16 @@ export function computeOwnedBorders(
     if (!neighbor) {
       neighbor = parentNeighbors[dir];
       neighborOwner = ownerOf(neighbor, parentOwnerId);
+      if (neighbor && neighbor.children) {
+        let idx;
+        if (dir === 'top') idx = (SUBDIV - 1) * SUBDIV + gx;
+        if (dir === 'bottom') idx = gx;
+        if (dir === 'left') idx = gy * SUBDIV + (SUBDIV - 1);
+        if (dir === 'right') idx = gy * SUBDIV;
+        const child = neighbor.children[idx];
+        const childOwner = ownerOf(child, neighborOwner);
+        return childOwner !== ownerId ? [[0, 1]] : [];
+      }
       if (parentOwnerId === ownerId) return [];
       return neighborOwner !== ownerId ? [[0, 1]] : [];
     }

--- a/client/test/ownedBorders.test.js
+++ b/client/test/ownedBorders.test.js
@@ -87,4 +87,170 @@ function grid(rows) {
   assert.deepStrictEqual(resChild.top, []);
 })();
 
+(function testCousinDifferentLevelDifferentOwners() {
+  const leftParent = makeTile('otherA');
+  leftParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const boundaryChild = makeTile('otherA');
+  leftParent.children[7] = boundaryChild; // top-right child
+  boundaryChild.children = Array.from({ length: 64 }, () => makeTile(null));
+  const grand = makeTile('me');
+  boundaryChild.children[7] = grand; // top-right grandchild
+
+  const rightParent = makeTile('otherB');
+  const grandRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => boundaryChild.children[y * 8 + x]));
+
+  const res = computeOwnedBorders(grand, grandRows, 7, 0, 'me', true, 'otherA', { right: rightParent });
+  const full = [[0, 1]];
+  assert.deepStrictEqual(res.right, full);
+})();
+
+(function testCousinDifferentLevelSameOwner() {
+  const leftParent = makeTile('me');
+  leftParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const boundaryChild = makeTile('me');
+  leftParent.children[7] = boundaryChild; // top-right child
+  boundaryChild.children = Array.from({ length: 64 }, () => makeTile(null));
+  const grand = makeTile('me');
+  boundaryChild.children[7] = grand; // top-right grandchild
+
+  const rightParent = makeTile('me');
+  const grandRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => boundaryChild.children[y * 8 + x]));
+
+  const res = computeOwnedBorders(grand, grandRows, 7, 0, 'me', true, 'me', { right: rightParent });
+  assert.deepStrictEqual(res.right, []);
+})();
+
+(function testAdjacentParentsChildrenSameOwner() {
+  const leftParent = makeTile('otherA');
+  leftParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftChild = makeTile('me');
+  leftParent.children[7] = leftChild; // top-right child
+
+  const rightParent = makeTile('otherB');
+  rightParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightChild = makeTile('me');
+  rightParent.children[0] = rightChild; // top-left child
+
+  const leftRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => leftParent.children[y * 8 + x]));
+  const rightRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => rightParent.children[y * 8 + x]));
+
+  const resLeft = computeOwnedBorders(leftChild, leftRows, 7, 0, 'me', true, 'otherA', { right: rightParent });
+  assert.deepStrictEqual(resLeft.right, []);
+
+  const resRight = computeOwnedBorders(rightChild, rightRows, 0, 0, 'me', true, 'otherB', { left: leftParent });
+  assert.deepStrictEqual(resRight.left, []);
+})();
+
+(function testThirdLevelCousinsSameOwner() {
+  const leftParent = makeTile('otherA');
+  leftParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftChild1 = makeTile('otherA');
+  leftParent.children[7] = leftChild1; // top-right
+  leftChild1.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftChild2 = makeTile('otherA');
+  leftChild1.children[7] = leftChild2; // top-right
+  leftChild2.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftLeaf = makeTile('me');
+  leftChild2.children[7] = leftLeaf; // top-right
+
+  const rightParent = makeTile('otherB');
+  rightParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightChild1 = makeTile('otherB');
+  rightParent.children[0] = rightChild1; // top-left
+  rightChild1.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightChild2 = makeTile('otherB');
+  rightChild1.children[0] = rightChild2; // top-left
+  rightChild2.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightLeaf = makeTile('me');
+  rightChild2.children[0] = rightLeaf; // top-left
+
+  const leftRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => leftChild2.children[y * 8 + x]));
+  const rightRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => rightChild2.children[y * 8 + x]));
+
+  const resLeft = computeOwnedBorders(leftLeaf, leftRows, 7, 0, 'me', true, 'otherA', { right: rightChild2 });
+  assert.deepStrictEqual(resLeft.right, []);
+
+  const resRight = computeOwnedBorders(rightLeaf, rightRows, 0, 0, 'me', true, 'otherB', { left: leftChild2 });
+  assert.deepStrictEqual(resRight.left, []);
+})();
+
+(function testThirdLevelCousinsDifferentOwners() {
+  const leftParent = makeTile('otherA');
+  leftParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftChild1 = makeTile('otherA');
+  leftParent.children[7] = leftChild1;
+  leftChild1.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftChild2 = makeTile('otherA');
+  leftChild1.children[7] = leftChild2;
+  leftChild2.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftLeaf = makeTile('me');
+  leftChild2.children[7] = leftLeaf;
+
+  const rightParent = makeTile('otherB');
+  rightParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightChild1 = makeTile('otherB');
+  rightParent.children[0] = rightChild1;
+  rightChild1.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightChild2 = makeTile('otherB');
+  rightChild1.children[0] = rightChild2;
+  rightChild2.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightLeaf = makeTile('otherC');
+  rightChild2.children[0] = rightLeaf;
+
+  const leftRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => leftChild2.children[y * 8 + x]));
+
+  const res = computeOwnedBorders(leftLeaf, leftRows, 7, 0, 'me', true, 'otherA', { right: rightChild2 });
+  const full = [[0, 1]];
+  assert.deepStrictEqual(res.right, full);
+})();
+
+(function testFourthLevelCousinsSameOwner() {
+  const leftParent = makeTile('otherA');
+  leftParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const l1 = makeTile('otherA');
+  leftParent.children[7] = l1;
+  l1.children = Array.from({ length: 64 }, () => makeTile(null));
+  const l2 = makeTile('otherA');
+  l1.children[7] = l2;
+  l2.children = Array.from({ length: 64 }, () => makeTile(null));
+  const l3 = makeTile('otherA');
+  l2.children[7] = l3;
+  l3.children = Array.from({ length: 64 }, () => makeTile(null));
+  const l4 = makeTile('me');
+  l3.children[7] = l4;
+
+  const rightParent = makeTile('otherB');
+  rightParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const r1 = makeTile('otherB');
+  rightParent.children[0] = r1;
+  r1.children = Array.from({ length: 64 }, () => makeTile(null));
+  const r2 = makeTile('otherB');
+  r1.children[0] = r2;
+  r2.children = Array.from({ length: 64 }, () => makeTile(null));
+  const r3 = makeTile('otherB');
+  r2.children[0] = r3;
+  r3.children = Array.from({ length: 64 }, () => makeTile(null));
+  const r4 = makeTile('me');
+  r3.children[0] = r4;
+
+  const leftRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => l3.children[y * 8 + x]));
+  const rightRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => r3.children[y * 8 + x]));
+
+  const resLeft = computeOwnedBorders(l4, leftRows, 7, 0, 'me', true, 'otherA', { right: r3 });
+  assert.deepStrictEqual(resLeft.right, []);
+
+  const resRight = computeOwnedBorders(r4, rightRows, 0, 0, 'me', true, 'otherB', { left: l3 });
+  assert.deepStrictEqual(resRight.left, []);
+})();
+
+
 console.log('owned border tests passed');


### PR DESCRIPTION
## Summary
- handle cousin tiles across parent boundaries
- ensure no border when adjacent parents have children owned by the same user
- add test verifying sibling parents with different owners do not draw borders between a player's tiles
- added tests for deeper cousin tiles (3rd and 4th level)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68541d95e7cc8325b1e4c2b118175740