### PR TITLE
Add log when pixel claimed

### DIFF
--- a/client/test/gridUtils.js
+++ b/client/test/gridUtils.js
@@ -1,0 +1,27 @@
+export function parseGrid(str) {
+  const rows = str.trim().split(/\n/).map(r => r.trim().replace(/\s+/g, ''));
+  const refs = {};
+  const grid = rows.map((line, y) => {
+    return Array.from(line).map((ch, x) => {
+      const tile = { owner: ch === '.' ? null : { id: ch, color: '#' + ch }, children: null };
+      if (ch !== '.') refs[ch] = { tile, x, y };
+      return tile;
+    });
+  });
+  return { grid, refs };
+}
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+export function address(x, y) {
+  return LETTERS[x] + String(y + 1);
+}
+export function addressForPath(path) {
+  const parts = [];
+  for (let level = 0; level < path.length; level++) {
+    const idx = path[level];
+    const x = idx % 8;
+    const y = Math.floor(idx / 8);
+    parts.push(address(x, y));
+  }
+  return parts.join('/');
+}

--- a/client/test/ownedBorders.test.js
+++ b/client/test/ownedBorders.test.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { computeOwnedBorders } from '../src/utils/ownedBorders.js';
+import { parseGrid, address, addressForPath } from './gridUtils.js';
 
 function makeTile(id) {
   return { owner: id ? { id, color: '#' + id } : null, children: null };
@@ -143,6 +144,17 @@ function grid(rows) {
 
   const resRight = computeOwnedBorders(rightChild, rightRows, 0, 0, 'me', true, 'otherB', { left: leftParent });
   assert.deepStrictEqual(resRight.left, []);
+})();
+
+(function testGridHelpers() {
+  const { grid, refs } = parseGrid(`
+    A.
+    .B
+  `);
+  assert.strictEqual(address(refs.A.x, refs.A.y), 'A1');
+  assert.strictEqual(address(refs.B.x, refs.B.y), 'B2');
+  const path = [refs.B.y * 8 + refs.B.x];
+  assert.strictEqual(addressForPath(path), 'B2');
 })();
 
 console.log('owned border tests passed');

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,22 @@ const WORLD_H = 6;
 const CLAIMS_TO_OWN = 3;
 const SUBDIV = 8;
 
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+function address(x, y) {
+  return LETTERS[x] + String(y + 1);
+}
+function addressForPath(path) {
+  const parts = [];
+  for (let level = 0; level < path.length; level++) {
+    const idx = path[level];
+    const width = level === 0 ? WORLD_W : SUBDIV;
+    const x = idx % width;
+    const y = Math.floor(idx / width);
+    parts.push(address(x, y));
+  }
+  return parts.join('/');
+}
+
 // ─── data model ────────────────────────────────────────────────────────────
 class Tile {
   constructor(level, owner = null) {
@@ -74,6 +90,7 @@ io.on('connection', socket => {
       tile.claims++;
       if (tile.claims >= CLAIMS_TO_OWN) {
         tile.owner = { id: socket.id, color };
+        console.log(`claimed ${addressForPath(path)}`);
         subdivide(tile);
       }
     }


### PR DESCRIPTION
## Summary
- log claimed tile address when claims reach ownership
- helper functions in server for computing addresses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855298a5e0c8325a3355c40a84cdd5c