### PR TITLE
Fix neighbor recursion and add border test

### DIFF
--- a/client/src/PixelCanvas.jsx
+++ b/client/src/PixelCanvas.jsx
@@ -118,6 +118,19 @@ function drawTileLines(
     tile.children.forEach((child, i) => {
       const cx = i % 8;
       const cy = Math.floor(i / 8);
+      const childParentNeighbors = {};
+      ['top', 'right', 'bottom', 'left'].forEach(side => {
+        let n = neighbors[side] || parentNeighbors[side] || null;
+        if (!neighbors[side] && parentNeighbors[side] && parentNeighbors[side].children) {
+          let idx;
+          if (side === 'top') idx = 7 * 8 + cx;
+          if (side === 'bottom') idx = cx;
+          if (side === 'left') idx = cy * 8 + 7;
+          if (side === 'right') idx = cy * 8;
+          n = parentNeighbors[side].children[idx];
+        }
+        childParentNeighbors[side] = n;
+      });
       drawTileLines(
         ctx,
         child,
@@ -131,7 +144,7 @@ function drawTileLines(
         showGrid,
         showOwnedBorders,
         tile.owner?.id || parentOwnerId,
-        neighbors,
+        childParentNeighbors,
       );
     });
   }

--- a/client/test/ownedBorders.test.js
+++ b/client/test/ownedBorders.test.js
@@ -146,6 +146,35 @@ function grid(rows) {
   assert.deepStrictEqual(resRight.left, []);
 })();
 
+(function testDeepNeighborsSameOwner() {
+  const leftRoot = makeTile('otherA');
+  leftRoot.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftParent = makeTile('otherA');
+  leftRoot.children[7] = leftParent; // H1
+  leftParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const leftGrand = makeTile('me');
+  leftParent.children[7] = leftGrand; // H1/H1
+
+  const rightRoot = makeTile('otherB');
+  rightRoot.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightParent = makeTile('otherB');
+  rightRoot.children[0] = rightParent; // A1
+  rightParent.children = Array.from({ length: 64 }, () => makeTile(null));
+  const rightGrand = makeTile('me');
+  rightParent.children[0] = rightGrand; // A1/A1
+
+  const leftGrandRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => leftParent.children[y * 8 + x]));
+  const rightGrandRows = Array.from({ length: 8 }, (_, y) =>
+    Array.from({ length: 8 }, (_, x) => rightParent.children[y * 8 + x]));
+
+  const resLeft = computeOwnedBorders(leftGrand, leftGrandRows, 7, 0, 'me', true, 'otherA', { right: rightParent });
+  assert.deepStrictEqual(resLeft.right, []);
+
+  const resRight = computeOwnedBorders(rightGrand, rightGrandRows, 0, 0, 'me', true, 'otherB', { left: leftParent });
+  assert.deepStrictEqual(resRight.left, []);
+})();
+
 (function testGridHelpers() {
   const { grid, refs } = parseGrid(`
     A.


### PR DESCRIPTION
## Summary
- recurse `drawTileLines` with correct parent neighbors
- ensure nested neighbors use the closest available tile
- test deep adjacent grandchildren owned by same player

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68553ca53210832592b4667898883080