### PR TITLE
Add pixel reset feature

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -11,6 +11,10 @@ function App() {
   const [showGrid, setShowGrid] = useState(true);
   const [showBorders, setShowBorders] = useState(true);
 
+  function handleReset() {
+    socket.emit('reset');
+  }
+
   useEffect(() => {
     socket.on('init', data => setWorld(data.world));
     socket.on('update', ({ path, tile }) => {
@@ -50,6 +54,7 @@ function App() {
         toggleGrid={() => setShowGrid(prev => !prev)}
         showBorders={showBorders}
         toggleBorders={() => setShowBorders(prev => !prev)}
+        resetPixels={handleReset}
       />
       <PixelCanvas
         world={world}

--- a/client/src/Toolbar.jsx
+++ b/client/src/Toolbar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function Toolbar({ showGrid, toggleGrid, showBorders, toggleBorders }) {
+export default function Toolbar({ showGrid, toggleGrid, showBorders, toggleBorders, resetPixels }) {
   return (
     <div className="toolbar">
       <label>
@@ -11,6 +11,7 @@ export default function Toolbar({ showGrid, toggleGrid, showBorders, toggleBorde
         <input type="checkbox" checked={showBorders} onChange={toggleBorders} />
         Owned borders
       </label>
+      <button onClick={resetPixels}>Reset pixels</button>
     </div>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -27,3 +27,8 @@ canvas {
 .toolbar label {
   display: block;
 }
+
+.toolbar button {
+  margin-top: 4px;
+  width: 100%;
+}

--- a/server/server.js
+++ b/server/server.js
@@ -41,7 +41,7 @@ function createWorld() {
   );
 }
 
-const world = createWorld();
+let world = createWorld();
 
 function getTile(path) {
   if (!Array.isArray(path) || path.length === 0) return null;
@@ -96,6 +96,11 @@ io.on('connection', socket => {
     }
 
     io.emit('update', { path, tile });
+  });
+
+  socket.on('reset', () => {
+    world = createWorld();
+    io.emit('init', { world });
   });
 });
 


### PR DESCRIPTION
## Summary
- add resetPixels button to the toolbar
- implement handler in App to emit `reset`
- handle `reset` event on the server
- style reset button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68553e8d72948325b3732995ae0362a5