### PR TITLE
Fix border drawing for parent tiles

### DIFF
--- a/client/src/PixelCanvas.jsx
+++ b/client/src/PixelCanvas.jsx
@@ -177,7 +177,6 @@ function collectTileLines(
         depth + 1,
       );
     });
-    return;
   }
 
   const drawGreen = computeOwnedBorders(tile, grid, gx, gy, myId, showOwnedBorders, parentOwnerId, parentNeighbors);


### PR DESCRIPTION
## Summary
- fix missing borders by continuing line collection after processing child tiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558ca596a08325912147a5c8e58ca6